### PR TITLE
Fix tense in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ## Installation
 
-The latest version of `swmpc` is available on the [App Store](https://apps.apple.com/app/swmpc/id6743818735). I've decided to make `swmpc` a paid app to help offset the many hours spend developing it, as well as expenses like the annual $100 Apple Developer License fee. Of course, you're also welcome to compile `swmpc` yourself from source.
+The latest version of `swmpc` is available on the [App Store](https://apps.apple.com/app/swmpc/id6743818735). I've decided to make `swmpc` a paid app to help offset the many hours spent developing it, as well as expenses like the annual $100 Apple Developer License fee. Of course, you're also welcome to compile `swmpc` yourself from source.
 
 `swmpc` is an universal app, meaning you only need to purchase it once to use it on both macOS and iOS.
 


### PR DESCRIPTION
_"Spent"_ is required because the clause refers to completed time investment prior to the decision, and English demands a past participle to form a reduced relative clause describing that past action.

_"Spend"_ is a bare infinitive or simple present, neither of which can function as a post-nominal passive modifier.