### PR TITLE
Show current audio format details

### DIFF
--- a/Packages/MPDKit/Sources/MPDKit/Commands/SharedCommands.swift
+++ b/Packages/MPDKit/Sources/MPDKit/Commands/SharedCommands.swift
@@ -25,12 +25,15 @@ public extension ConnectionManager {
     ///   - `elapsed`: The elapsed playback time in seconds.
     ///   - `song`: The currently playing song, if any.
     ///   - `volume`: The current volume level (0-100).
+    ///   - `bitrate`: The current decoded stream bitrate in kilobits per second.
+    ///   - `audioFormat`: MPD's `sampleRate:bits:channels` audio description.
     /// - Throws: An error if the response is malformed or if the underlying
     ///           command execution fails.
     func getStatusData() async throws -> (state: PlayerState?, isConsume: Bool?,
                                           isRandom: Bool?, isRepeat: Bool?,
                                           elapsed: Double?, song: Song?, volume:
-                                          Int?)
+                                          Int?, bitrate: Int?, audioFormat:
+                                          String?)
     {
         let lines = try await run(["status", "currentsong"])
 
@@ -60,6 +63,8 @@ public extension ConnectionManager {
         let isRepeat = fields["repeat"].map { $0 == "1" }
         let elapsed = fields["elapsed"].flatMap(Double.init)
         let volume = fields["volume"].flatMap(Int.init)
+        let bitrate = fields["bitrate"].flatMap(Int.init)
+        let audioFormat = fields["audio"]
 
         let song: Song? = if fields["file"] != nil {
             try Song.parse(fields: fields, index: nil)
@@ -67,7 +72,8 @@ public extension ConnectionManager {
             nil
         }
 
-        return (state, isConsume, isRandom, isRepeat, elapsed, song, volume)
+        return (state, isConsume, isRandom, isRepeat, elapsed, song, volume,
+                bitrate, audioFormat)
     }
 
     /// Retrieves statistics from the MPD server.

--- a/swmpc/Models/MPD/StatusManager.swift
+++ b/swmpc/Models/MPD/StatusManager.swift
@@ -44,6 +44,74 @@ import WidgetKit
     /// The current volume level (0-100).
     private(set) var volume: Int?
 
+    /// The current decoded stream bitrate in kilobits per second.
+    private(set) var bitrate: Int?
+
+    /// MPD's raw `sampleRate:bits:channels` description for the current stream.
+    private(set) var audioFormat: String?
+
+    /// A compact, human-readable description of the current file and stream.
+    var technicalDetails: String? {
+        var details: [String] = []
+
+        if let fileFormat {
+            details.append(fileFormat)
+        }
+
+        if let audioFormat {
+            let fields = audioFormat.split(separator: ":", omittingEmptySubsequences: false)
+            if fields.count == 3 {
+                let sampleRate = Int(fields[0]).flatMap { $0 > 0 ? $0 : nil }
+                let bits = Int(fields[1]).flatMap { $0 > 0 ? $0 : nil }
+
+                switch (bits, sampleRate) {
+                case let (bits?, sampleRate?):
+                    details.append("\(bits)-bit/\(Self.format(sampleRate: sampleRate))")
+                case let (bits?, nil):
+                    details.append("\(bits)-bit")
+                case let (nil, sampleRate?):
+                    details.append(Self.format(sampleRate: sampleRate))
+                case (nil, nil):
+                    break
+                }
+
+                if let channels = Int(fields[2]), channels > 0 {
+                    details.append("\(channels) ch")
+                }
+            }
+        }
+
+        if let bitrate, bitrate > 0 {
+            details.append("\(bitrate) kbps")
+        }
+
+        return details.isEmpty ? nil : details.joined(separator: " • ")
+    }
+
+    /// The uppercase file extension for the current song or stream URL.
+    private var fileFormat: String? {
+        guard let file = song?.file else {
+            return nil
+        }
+
+        let path = URL(string: file)?.path.isEmpty == false
+            ? URL(string: file)?.path ?? file
+            : file
+        let fileExtension = URL(fileURLWithPath: path).pathExtension
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return fileExtension.isEmpty ? nil : fileExtension.uppercased()
+    }
+
+    /// Formats a sample rate without unnecessary decimal places.
+    private static func format(sampleRate: Int) -> String {
+        let kilohertz = Double(sampleRate) / 1_000
+        let value = kilohertz.rounded() == kilohertz
+            ? String(Int(kilohertz))
+            : kilohertz.formatted(.number.precision(.fractionLength(1)))
+        return "\(value) kHz"
+    }
+
     /// Whether elapsed time tracking is currently active.
     @ObservationIgnored private(set) var trackElapsed = false {
         didSet {
@@ -158,6 +226,8 @@ import WidgetKit
         }
 
         _ = volume.update(to: data.volume)
+        _ = bitrate.update(to: data.bitrate)
+        _ = audioFormat.update(to: data.audioFormat)
     }
 
     /// Starts tracking elapsed time for the current song.

--- a/swmpc/Views/Detail/DetailFooterView.swift
+++ b/swmpc/Views/Detail/DetailFooterView.swift
@@ -42,6 +42,14 @@ struct DetailFooterView: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                     }
+
+                    if let technicalDetails = mpd.status.technicalDetails {
+                        Text(technicalDetails)
+                            .font(.system(size: 11, design: .rounded))
+                            .monospacedDigit()
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
                 }
                 .contextMenu {
                     if let songTitleForClipboard {


### PR DESCRIPTION
## Summary
- parse MPD `bitrate` and `audio` status fields alongside the current song
- derive a readable file-format label from the song path
- show a compact technical line under the artist, for example `FLAC • 24-bit/96 kHz • 2 ch • 2652 kbps`
- omit individual values cleanly when MPD does not report them

## Testing
- `swift build --package-path Packages/MPDKit`
- `git diff --check origin/main...HEAD`
- built, installed, and launch-tested the feature against a live MPD server from the macOS 26-compatible source baseline; verified live FLAC, sample-rate, bit-depth, channel, and bitrate values in the now-playing UI

The full app was not rebuilt after rebasing onto current `main` because it now requires the macOS 27 SDK, while the available host SDK is macOS 26.5.

Closes #72